### PR TITLE
:adhesive_bandage: 버튼의 기본 variant값 설정

### DIFF
--- a/packages/parte-ui/src/Button/Button.tsx
+++ b/packages/parte-ui/src/Button/Button.tsx
@@ -5,10 +5,11 @@ export const Button = ({
   children,
   leadingIcon,
   trailingIcon,
+  variant = "primary",
   ...props
 }: ButtonProps) => {
   return (
-    <StyledButton {...props}>
+    <StyledButton variant={variant} {...props}>
       {leadingIcon}
       {children}
       {trailingIcon}


### PR DESCRIPTION
fix #6 

버튼 컴포넌트의 `variant`를 기본으로 primary로 지정하도록 변경.