### PR TITLE
:bug: card 컴포넌트 width, height props 버그 수정 

### DIFF
--- a/packages/parte-ui/src/Card/Card.styled.ts
+++ b/packages/parte-ui/src/Card/Card.styled.ts
@@ -1,16 +1,14 @@
-import styled, { css } from 'styled-components';
-import { Box } from '../Layout';
+import styled, { css } from 'styled-components'
+import { Box } from '../Layout'
 
 const CommonStyle = css`
   ${({ theme }) => css`
     border: 1px solid ${theme.colors.N400};
     background-color: ${theme.colors.N0};
     border-radius: 8px;
-    width: fit-content;
-    height: fit-content;
     box-sizing: border-box;
   `}
-`;
+`
 
 export const DefaultCard = styled(Box)<{ disabled?: boolean }>`
   ${({ theme, disabled }) => css`
@@ -35,11 +33,11 @@ export const DefaultCard = styled(Box)<{ disabled?: boolean }>`
       }
     `}
   `}
-`;
+`
 
 export const SelectableCard = styled(Box)<{
-  disabled?: boolean;
-  selected?: boolean;
+  disabled?: boolean
+  selected?: boolean
 }>`
   ${({ theme, disabled, selected }) => css`
     ${CommonStyle}
@@ -71,4 +69,4 @@ export const SelectableCard = styled(Box)<{
       background-color: ${theme.colors.N50};
     `}
   `}
-`;
+`

--- a/packages/parte-ui/src/Card/Card.tsx
+++ b/packages/parte-ui/src/Card/Card.tsx
@@ -1,9 +1,19 @@
-import * as Styled from "./Card.styled";
-import { CardProps } from "./Card.types";
+import * as Styled from './Card.styled'
+import { CardProps } from './Card.types'
 
-export const Card = ({ type = "default", children, ...props }: CardProps) => {
+export const Card = ({
+  type = 'default',
+  children,
+  width = 'fit-content',
+  height = 'fit-content',
+  ...props
+}: CardProps) => {
   const CardComponent =
-    type === "default" ? Styled.DefaultCard : Styled.SelectableCard;
+    type === 'default' ? Styled.DefaultCard : Styled.SelectableCard
 
-  return <CardComponent {...props}>{children}</CardComponent>;
-};
+  return (
+    <CardComponent width={width} height={height} {...props}>
+      {children}
+    </CardComponent>
+  )
+}


### PR DESCRIPTION
# 개요
close #17 

- Card 컴포넌트는 props는 BoxProps도 포함하고 있는데, 그 안에 width, height에 fit-content가 설정되어 있었음. 그래서 이 두 속성을 삭제.
- Card 컴포넌트가 width, height를 옵셔널하게 받고, undefined일 경우 fit-content 부여.

