### PR TITLE
:bug: Tab을 div로 변경해서 a 태그도 넣을 수 있도록 변경

### DIFF
--- a/apps/web/src/pages/tab/index.tsx
+++ b/apps/web/src/pages/tab/index.tsx
@@ -1,0 +1,39 @@
+import { Box, Tab, Tabs } from "@parte-ds/ui";
+import Link from "next/link";
+import { useState } from "react";
+
+const TAB_LIST = [
+  { label: "Google", value: "https://www.google.com" },
+  {
+    label: "Naver",
+    value: "https://www.naver.com",
+  },
+  {
+    label: "Bing",
+    value: "https://www.bing.com",
+  },
+];
+
+const TabTest = () => {
+  const [idx, setIdx] = useState(0);
+  return (
+    <Box padding={30}>
+      <Tabs>
+        {TAB_LIST.map(({ label, value }, i) => (
+          <Tab
+            key={label}
+            variant="Primary"
+            selected={i === idx}
+            onClick={() => setIdx(i)}
+            // disabled
+          >
+            <Link href={value} tabIndex={-1}>
+              {label}
+            </Link>
+          </Tab>
+        ))}
+      </Tabs>
+    </Box>
+  );
+};
+export default TabTest;

--- a/packages/parte-ui/src/Tabs/SidebarTab/SidebarTab.tsx
+++ b/packages/parte-ui/src/Tabs/SidebarTab/SidebarTab.tsx
@@ -2,10 +2,12 @@ import { forwardRef } from "react";
 import { Tab } from "../Tab/Tab";
 import { SidebarTabProps } from "./SidebarTab.types";
 
-export const SidebarTab = forwardRef<HTMLButtonElement, SidebarTabProps>(
+export const SidebarTab = forwardRef<HTMLDivElement, SidebarTabProps>(
   (props: SidebarTabProps, ref) => {
     return (
       <Tab ref={ref} {...props} variant="Secondary" direction="vertical" />
     );
   }
 );
+
+SidebarTab.displayName = "SidebarTab";

--- a/packages/parte-ui/src/Tabs/Tab/Tab.styled.ts
+++ b/packages/parte-ui/src/Tabs/Tab/Tab.styled.ts
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { TabProps } from "./Tab.types";
 
-export const Tab = styled.button<TabProps>`
+export const Tab = styled.div<TabProps>`
   ${({ theme, variant, selected, disabled, direction }) => {
     const primaryTabStyle = css`
       position: relative;
@@ -59,13 +59,20 @@ export const Tab = styled.button<TabProps>`
           }
         }
       `}
-      &:disabled {
-        color: ${theme.colors.N500};
-        svg {
-          color: ${theme.colors.N400};
+      ${disabled &&
+      css`
+        &,
+        &:hover,
+        &:active,
+        &:focus {
+          color: ${theme.colors.N500};
+          svg {
+            color: ${theme.colors.N400};
+          }
+          cursor: default;
+          outline: none;
         }
-        cursor: default;
-      }
+      `}
     `;
     const secondaryTabStyle = css`
       padding: 8px 16px;
@@ -122,14 +129,21 @@ export const Tab = styled.button<TabProps>`
           }
         }
       `}
-      &:disabled {
-        color: ${theme.colors.N500};
-        background-color: ${selected ? theme.colors.N100 : "transparent"};
-        svg {
+      ${disabled &&
+      css`
+        &,
+        &:hover,
+        &:active,
+        &:focus {
           color: ${theme.colors.N500};
+          background-color: ${selected ? theme.colors.N100 : "transparent"};
+          svg {
+            color: ${theme.colors.N500};
+          }
+          cursor: default;
+          outline: none;
         }
-        cursor: default;
-      }
+      `}
     `;
 
     return css`

--- a/packages/parte-ui/src/Tabs/Tab/Tab.tsx
+++ b/packages/parte-ui/src/Tabs/Tab/Tab.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 import * as Styled from "./Tab.styled";
 import { TabProps } from "./Tab.types";
 
-export const Tab = forwardRef<HTMLButtonElement, TabProps>(
+export const Tab = forwardRef<HTMLDivElement, TabProps>(
   (props: TabProps, ref) => {
     const {
       leadingIcon,
@@ -10,15 +10,28 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
       children,
       variant = "Primary",
       direction = "horizontal",
+      tabIndex = 0,
+      onClick,
+      onFocus,
+      disabled,
     } = props;
 
     return (
       <Styled.Tab
         ref={ref}
-        type="button"
+        tabIndex={disabled ? -1 : tabIndex}
         {...props}
         variant={variant}
         direction={direction}
+        disabled={disabled}
+        onClick={(e) => {
+          if (disabled) return;
+          onClick?.(e);
+        }}
+        onFocus={(e) => {
+          if (disabled) return;
+          onFocus?.(e);
+        }}
       >
         {leadingIcon}
         {children}
@@ -27,3 +40,4 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
     );
   }
 );
+Tab.displayName = "Tab";

--- a/packages/parte-ui/src/Tabs/Tab/Tab.types.ts
+++ b/packages/parte-ui/src/Tabs/Tab/Tab.types.ts
@@ -1,9 +1,9 @@
-import React, { ButtonHTMLAttributes } from "react";
+import React, { HTMLAttributes } from "react";
 
 export type TabVariant = "Primary" | "Secondary";
 export type TabDirection = "horizontal" | "vertical";
 
-export type TabProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+export type TabProps = HTMLAttributes<HTMLDivElement> & {
   leadingIcon?: React.ReactNode;
   trailingIcon?: React.ReactNode;
   children?: React.ReactNode;
@@ -11,4 +11,5 @@ export type TabProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   selected?: boolean;
   disabled?: boolean;
   direction?: TabDirection;
+  tabIndex?: number;
 };


### PR DESCRIPTION
close #59 

## 개요
Tab의 쓰임새가 2가지가 있다고 생각했습니다.
1. URL의 변동이 없는 경우: Tab을 선택했을때 Component의 상태값을 변경하여 UI를 변경
2. URL이 변하는 경우: Tab을 선택했을때 다른 페이지로 이동

현재 Tab은 `button` 태그로 되어있기 때문에 1번의 경우는 잘 지원하지만 2번의 경우 `a` 태그를 사용해야하는데
`button`안에 `a`는 semantic하지 않습니다.

따라서 Tab을 `div`로 변경하고 개발자가 원하는대로 tag를 표현할 수 있도록 변경했습니다.

### 기타
`div`에서 disabled의 속성은 기본적으로 먹히지 않아서
onClick, onFocus, tabIndex를 disabled 일 때는 작동하지 않도록 수정했습니다