### PR TITLE
:bug: Toast 컴포넌트를 사용할때 react 18 버전만 호환되도록 변경

### DIFF
--- a/apps/web/src/pages/toast/index.tsx
+++ b/apps/web/src/pages/toast/index.tsx
@@ -1,0 +1,20 @@
+import { Box, Button, toaster } from "@parte-ds/ui";
+
+const Toast = () => {
+  return (
+    <Box padding={30}>
+      <Button
+        onClick={() =>
+          toaster.notify({
+            status: "info",
+            title: "title",
+            description: "description",
+          })
+        }
+      >
+        토스트 실행
+      </Button>
+    </Box>
+  );
+};
+export default Toast;

--- a/packages/parte-ui/src/Toaster/Toaster.tsx
+++ b/packages/parte-ui/src/Toaster/Toaster.tsx
@@ -1,8 +1,8 @@
-import ReactDOM from "react-dom";
+import ReactClientDOM from "react-dom/client";
 import { ThemeProvider } from "styled-components";
 import { theme } from "../@foundations/theme";
-import { NotifyHandler, RemoveHandler } from "./Toaster.types";
 import { ToastManager } from "./ToastManager";
+import { NotifyHandler, RemoveHandler } from "./Toaster.types";
 
 /**
  * The Toaster manages the interactions between
@@ -10,18 +10,13 @@ import { ToastManager } from "./ToastManager";
  */
 
 interface IToaster {
-  notifyHandler: NotifyHandler;
-  removeHandler: RemoveHandler;
+  notify: NotifyHandler;
+  remove: RemoveHandler;
 }
 
-const getMajorVersion = (version: string) => {
-  const majorVersion = parseInt(version, 10);
-  return majorVersion;
-};
-
 export class Toaster implements IToaster {
-  notifyHandler: NotifyHandler = () => {};
-  removeHandler: RemoveHandler = () => {};
+  private $notifyHandler: NotifyHandler = () => {};
+  private $removeHandler: RemoveHandler = () => {};
 
   constructor() {
     const canUseDom = Boolean(typeof window !== "undefined" && window.document);
@@ -31,7 +26,7 @@ export class Toaster implements IToaster {
     container.setAttribute("toaster-container", "");
     document.body.appendChild(container);
 
-    const toastManager = () => {
+    const Manager = () => {
       return (
         <ThemeProvider theme={theme}>
           <ToastManager
@@ -42,34 +37,22 @@ export class Toaster implements IToaster {
       );
     };
 
-    if (getMajorVersion(ReactDOM.version) >= 18) {
-      try {
-        const { createRoot } = require("react-dom/client");
-        const root = createRoot(container);
-
-        root.render(toastManager());
-      } catch (e) {
-        ReactDOM.render(toastManager(), container);
-      }
-      return;
-    }
-
-    ReactDOM.render(toastManager(), container);
+    ReactClientDOM.createRoot(container).render(<Manager />);
   }
 
-  _bindNotify = (handler: NotifyHandler) => {
-    this.notifyHandler = handler;
+  private _bindNotify = (handler: NotifyHandler) => {
+    this.$notifyHandler = handler;
   };
 
-  _bindRemove = (handler: RemoveHandler) => {
-    this.removeHandler = handler;
+  private _bindRemove = (handler: RemoveHandler) => {
+    this.$removeHandler = handler;
   };
 
   notify: NotifyHandler = (toastProps) => {
-    return this.notifyHandler(toastProps);
+    return this.$notifyHandler(toastProps);
   };
 
   remove: RemoveHandler = (id) => {
-    return this.removeHandler(id);
+    return this.$removeHandler(id);
   };
 }


### PR DESCRIPTION
close #63 

현재 어차피 peerDependencies로 react 18버전 설치하라고 명시하고 있고
자꾸 쓸때 react에서 createRoot 쓰라고 워닝 띄우니 아예 변경했습니다