### PR TITLE
:bug: Box 컴포넌트의 props들을 구분해서 styled-components, JSX에 주입하기

### DIFF
--- a/packages/parte-ui/src/Dialog/Dialog.tsx
+++ b/packages/parte-ui/src/Dialog/Dialog.tsx
@@ -148,3 +148,5 @@ export const Dialog = memo(
     );
   }
 );
+
+Dialog.displayName = "Dialog";

--- a/packages/parte-ui/src/Dialog/Dialog.types.ts
+++ b/packages/parte-ui/src/Dialog/Dialog.types.ts
@@ -1,13 +1,8 @@
 import { ReactNode } from "react";
 import { TransitionStatus } from "react-transition-group";
-import {
-  DefaultTheme,
-  FlattenInterpolation,
-  ThemedStyledProps,
-} from "styled-components";
+import { FlattenSimpleInterpolation } from "styled-components";
 import { ElevationToken } from "../@foundations";
 import { ButtonVariant } from "../Button/Button.types";
-import { BoxProps } from "../Layout/Box.types";
 
 export type DialogSubCompProps = { close: () => void };
 export type DialogSubComponent = ({ close }: DialogSubCompProps) => ReactNode;
@@ -33,7 +28,5 @@ export interface DialogProps {
   width?: number;
   elevation?: ElevationToken;
   state?: TransitionStatus;
-  overrideStyles?: FlattenInterpolation<
-    ThemedStyledProps<BoxProps, DefaultTheme>
-  >;
+  overrideStyles?: FlattenSimpleInterpolation;
 }

--- a/packages/parte-ui/src/Layout/Box.tsx
+++ b/packages/parte-ui/src/Layout/Box.tsx
@@ -1,17 +1,21 @@
 import { forwardRef } from "react";
 import styled from "styled-components";
-import { commonBoxStyle } from "./Box.styled";
-import { BoxProps } from "./Box.types";
+import { getBoxStyleAndHtmlProps } from "../utils/box.util";
+import { BoxProps, InnerBoxProps } from "./Box.types";
 
-const StyledBox = styled.div<BoxProps>`
-  ${commonBoxStyle}
-  ${({ overrideStyles }) => overrideStyles}
+const StyledBox = styled.div<InnerBoxProps>`
+  ${({ $style }) => $style}
 `;
 
 export const Box = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
+  const [boxStyle, htmlProps] = getBoxStyleAndHtmlProps(props);
+  const { children, ...rest } = htmlProps;
+
   return (
-    <StyledBox ref={ref} {...props}>
-      {props.children}
+    <StyledBox ref={ref} $style={boxStyle} {...rest}>
+      {children}
     </StyledBox>
   );
 });
+
+Box.displayName = "Box";

--- a/packages/parte-ui/src/Layout/Box.types.ts
+++ b/packages/parte-ui/src/Layout/Box.types.ts
@@ -1,21 +1,17 @@
-import { HTMLAttributes, ReactNode } from "react";
+import { HTMLAttributes, PropsWithChildren } from "react";
+import { FlattenSimpleInterpolation } from "styled-components";
+import { ElevationToken, SPACING, Spacing } from "../@foundations";
 import {
-  DefaultTheme,
-  FlattenInterpolation,
-  ThemedStyledProps,
-} from "styled-components";
-import { SPACING, Spacing, ElevationToken } from "../@foundations";
-import {
+  AlignContent,
+  AlignItems,
+  AlignSelf,
   Display,
   FlexDirection,
-  JustifyContent,
-  AlignItems,
-  AlignContent,
   FlexWrap,
-  AlignSelf,
+  JustifyContent,
 } from "../constant";
 
-export type BoxProps = HTMLAttributes<HTMLDivElement> & {
+export type ParteStyledProps = {
   display?: Display;
   width?: string | number;
   height?: string | number;
@@ -59,15 +55,12 @@ export type BoxProps = HTMLAttributes<HTMLDivElement> & {
 
   elevation?: ElevationToken;
   borderRadius?: number | string;
-
-  /**
-   * @uxpinignoreprop
-   */
-  overrideStyles?: FlattenInterpolation<
-    ThemedStyledProps<BoxProps, DefaultTheme>
-  >;
-  /**
-   * @uxpinignoreprop
-   */
-  children?: ReactNode;
+  overrideStyles?: FlattenSimpleInterpolation;
 };
+
+export type NativeBoxProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+
+export type InnerBoxProps = NativeBoxProps & {
+  $style: FlattenSimpleInterpolation;
+};
+export type BoxProps = NativeBoxProps & ParteStyledProps;

--- a/packages/parte-ui/src/utils/box.util.ts
+++ b/packages/parte-ui/src/utils/box.util.ts
@@ -1,14 +1,12 @@
-import { css } from "styled-components";
-import { getElevation } from "../utils/elevation.util";
-import {
-  getWidthStyle,
-  getFlexBasisStyle,
-  getHeightStyle,
-} from "../utils/style.util";
-import { BoxProps } from "./Box.types";
+import { FlattenSimpleInterpolation, css } from "styled-components";
+import { ParteStyledProps } from "../Layout/Box.types";
+import { getElevation } from "./elevation.util";
+import { getFlexBasisStyle, getHeightStyle, getWidthStyle } from "./style.util";
 
-export const commonBoxStyle = css<BoxProps>`
-  ${({
+export const getBoxStyleAndHtmlProps = <T extends ParteStyledProps>(
+  styleProps: T
+): [FlattenSimpleInterpolation, Omit<T, keyof ParteStyledProps>] => {
+  const {
     display = "block",
     width,
     height,
@@ -47,7 +45,11 @@ export const commonBoxStyle = css<BoxProps>`
     marginRight,
     elevation,
     borderRadius,
-  }) =>
+    overrideStyles,
+    ...htmlProps
+  } = styleProps;
+
+  return [
     css`
       display: ${display};
       ${getWidthStyle(width)};
@@ -118,5 +120,8 @@ export const commonBoxStyle = css<BoxProps>`
               ? `${borderRadius}px`
               : borderRadius};
           `};
-    `}
-`;
+      ${overrideStyles}
+    `,
+    htmlProps,
+  ];
+};


### PR DESCRIPTION
close #71 

```tsx
  <StyledBox ref={ref} {...props}>
     {props.children}
   </StyledBox>
```

props를 구조할당분해로 모두 StyledBox로 주입하고 있었습니다.
그렇다보니 사실상 styled-components에서만 쓰일 스타일링을 위한 props가 쓸데없이 JSX인 `<div />`에 들어가게 되었고
React는 div에 margin, padding 같은 props들을 찾을 수 없다고 경고하고 있던 상황입니다.

따라서 styled-components에 주입되는 props와 JSX에 주입되는 props를 일단 Box를 가지고 구현해 보았습니다.

`$style`처럼 앞에 `$`를 붙여서 styled-component에 넘겨주면 JSX에는 최종적으로 반영되지 않는 feature를 [공식문서](https://styled-components.com/docs/api#transient-props)에서 확인하여 참고했습니다

Box 말고 다른 컴포넌트도 사실상 다 적용해줘야 하는 상황입니다.