### PR TITLE
:lipstick: InputWrapper에 disabled 스타일 추가

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  compiler: {
+    styledComponents: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -32,6 +32,9 @@ export default function Home() {
           <LinkContainer>
             <Link href="/new-icons">새로운 아이콘들</Link>
           </LinkContainer>
+          <LinkContainer>
+            <Link href="/input-wrapper">Input Wrapper 테스트</Link>
+          </LinkContainer>
         </Box>
         <Box padding={30} display="flex" flexDirection="column" gap={4}>
           <TextInput label="test" direction="horizontal" width={160} />

--- a/apps/web/src/pages/input-wrapper.tsx
+++ b/apps/web/src/pages/input-wrapper.tsx
@@ -1,0 +1,63 @@
+import {
+  Box,
+  FilePicker,
+  Select,
+  TagInput,
+  TextInput,
+  Textarea,
+} from "@parte-ds/ui";
+
+const InputWrapperTest = () => {
+  return (
+    <Box width="100vw" height="100vh">
+      <Box padding={32} display="flex" flexDirection="column" gap={16}>
+        <TextInput
+          width={260}
+          label="Label"
+          description="This is Description"
+          id="text-input"
+          required
+        />
+        <TextInput
+          width={260}
+          label="Label"
+          description="This is Description"
+          id="text-input-horizontal"
+          required
+          direction="horizontal"
+        />
+        <Textarea
+          id="textarea"
+          width={260}
+          label="Label"
+          description="This is Description"
+        />
+        <Select
+          width={260}
+          label="Label"
+          description="This is Description"
+          type="static"
+          options={[{ label: "Option 1", value: "1" }]}
+          isDisabled
+        />
+        <TagInput
+          id="taginput"
+          width={260}
+          label="Label"
+          description="This is Description"
+          values={[{ label: "Option 1", value: "1", status: "normal" }]}
+          onAdd={() => {}}
+          onRemove={() => {}}
+        />
+        <FilePicker
+          id="filepicker"
+          width={260}
+          label="Label"
+          description="This is Description"
+          name="ㅎㅇㅎㅇ"
+        />
+      </Box>
+    </Box>
+  );
+};
+export default InputWrapperTest;

--- a/packages/parte-ui/src/FilePicker/FilePicker.tsx
+++ b/packages/parte-ui/src/FilePicker/FilePicker.tsx
@@ -87,6 +87,8 @@ export const FilePicker = ({
       errorText={errorText}
       direction={direction}
       width={width}
+      disabled={disabled}
+      id={name}
     >
       <Styled.Container>
         <input
@@ -119,6 +121,7 @@ export const FilePicker = ({
             errorText={errorText}
             placeholder={placeholder}
             value={inputText(files)}
+            readOnly
           />
         </Styled.FilePickerInput>
         <Styled.FilePickerButton

--- a/packages/parte-ui/src/InputWrapper/InputWrapper.styled.ts
+++ b/packages/parte-ui/src/InputWrapper/InputWrapper.styled.ts
@@ -14,13 +14,20 @@ export const Label = styled.label`
   ${({ theme }) => css`
     ${theme.typography.H400}
     color: ${theme.colorHeading};
+    &[data-hasid="true"] {
+      cursor: pointer;
+    }
+    &[data-disabled="true"] {
+      color: ${theme.colors.N700};
+      cursor: default;
+    }
   `}
 `;
 
 export const Description = styled.p`
   ${({ theme }) => css`
     ${theme.typography.P100}
-    color: ${theme.colorParagraph};
+    color: ${theme.colors.N700};
     margin-bottom: ${theme.spacing.spacing2}px;
   `}
 `;

--- a/packages/parte-ui/src/InputWrapper/InputWrapper.tsx
+++ b/packages/parte-ui/src/InputWrapper/InputWrapper.tsx
@@ -1,9 +1,8 @@
-import { useId } from "react";
+import { useTheme } from "styled-components";
 import { Caption } from "../@foundations";
 import { Box } from "../Layout";
 import * as Styled from "./InputWrapper.styled";
 import { InputWrapperProps } from "./InputWrapper.types";
-import { useTheme } from "styled-components";
 
 export const InputWrapper = ({
   direction = "vertical",
@@ -22,9 +21,9 @@ const VerticalLayout = ({
   required = false,
   errorText,
   width,
+  disabled,
+  id,
 }: InputWrapperProps) => {
-  const id = useId();
-
   return (
     <Styled.Container flexDirection="column" width={width}>
       {label && (
@@ -41,7 +40,9 @@ const VerticalLayout = ({
           )}
           <Styled.Label
             htmlFor={id}
-            title={required ? "This field is required" : ""}
+            title={required ? "This field is required" : undefined}
+            data-disabled={disabled}
+            data-hasid={!!id}
           >
             {label}
           </Styled.Label>
@@ -62,8 +63,9 @@ const HorizontalLayout = ({
   errorText,
   width,
   labelWidth,
+  id,
+  disabled,
 }: InputWrapperProps) => {
-  const id = useId();
   const { spacing } = useTheme();
 
   return (
@@ -90,7 +92,9 @@ const HorizontalLayout = ({
           )}
           <Styled.Label
             htmlFor={id}
-            title={required ? "This field is required" : ""}
+            title={required ? "This field is required" : undefined}
+            data-disabled={disabled}
+            data-hasid={!!id}
           >
             {label}
           </Styled.Label>

--- a/packages/parte-ui/src/InputWrapper/InputWrapper.types.ts
+++ b/packages/parte-ui/src/InputWrapper/InputWrapper.types.ts
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
 export type InputWrapperDirection = "horizontal" | "vertical";
 
@@ -8,6 +8,8 @@ export type InputWrapperProps = PropsWithChildren<{
   description?: string;
   required?: boolean;
   errorText?: string;
+  disabled?: boolean;
+  id?: string;
   width?: number | string;
   labelWidth?: number | string;
 }>;

--- a/packages/parte-ui/src/Select/Select.tsx
+++ b/packages/parte-ui/src/Select/Select.tsx
@@ -192,6 +192,7 @@ export function Select<T>(props: SelectProps<T>) {
     showSearchIcon = false,
     styles: customStyles,
     components: customComponents,
+    id,
   } = props;
 
   const styles = useSelectStyle({ isError, customStyles }) as StylesConfig<
@@ -266,6 +267,7 @@ export function Select<T>(props: SelectProps<T>) {
       <StaticSelect
         components={defaultComponents}
         {...props}
+        id={id}
         ref={selectRef}
         onFocus={onFocus}
         onBlur={onBlur}
@@ -287,6 +289,7 @@ export function Select<T>(props: SelectProps<T>) {
           MenuList,
         }}
         {...props}
+        id={id}
         selectRef={selectRef}
         isDisabled={isDisabled}
         onFocus={onFocus}
@@ -312,6 +315,8 @@ export function Select<T>(props: SelectProps<T>) {
       errorText={errorText}
       direction={direction}
       labelWidth={labelWidth}
+      disabled={isDisabled}
+      id={id}
     >
       {SelectComponent}
     </InputWrapper>

--- a/packages/parte-ui/src/Select/Select.types.ts
+++ b/packages/parte-ui/src/Select/Select.types.ts
@@ -15,7 +15,10 @@ export type SelectAdditional =
     }
   | undefined;
 
-export type CommonSelectProps = Omit<InputWrapperProps, "children"> &
+export type CommonSelectProps = Omit<
+  InputWrapperProps,
+  "children" | "disabled"
+> &
   Pick<BoxProps, "width"> & {
     isError?: boolean;
     showSearchIcon?: boolean;

--- a/packages/parte-ui/src/TagInput/TagInput.tsx
+++ b/packages/parte-ui/src/TagInput/TagInput.tsx
@@ -1,17 +1,16 @@
 import {
-  FocusEvent,
-  forwardRef,
-  KeyboardEvent,
-  useState,
   ChangeEvent,
-  useId,
+  FocusEvent,
+  KeyboardEvent,
+  forwardRef,
+  useState,
 } from "react";
-import * as Styled from "./TagInput.styled";
-import { Box } from "../Layout";
-import { TagInputProps } from "./TagInput.types";
-import { Tag } from "./Tag";
-import { InputWrapper } from "../InputWrapper";
 import { useTheme } from "styled-components";
+import { InputWrapper } from "../InputWrapper";
+import { Box } from "../Layout";
+import { Tag } from "./Tag";
+import * as Styled from "./TagInput.styled";
+import { TagInputProps } from "./TagInput.types";
 
 export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
   (
@@ -26,7 +25,6 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
     }: TagInputProps,
     ref
   ) => {
-    const id = useId();
     const { spacing } = useTheme();
     const {
       label,
@@ -38,6 +36,7 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
       onFocus,
       direction,
       width,
+      id,
     } = props;
 
     const [hover, setHover] = useState(false);
@@ -86,6 +85,8 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
         errorText={errorText}
         direction={direction}
         width={width}
+        disabled={disabled}
+        id={id}
       >
         <Styled.InputWrapper
           hover={hover}

--- a/packages/parte-ui/src/TextInput/TextInput.tsx
+++ b/packages/parte-ui/src/TextInput/TextInput.tsx
@@ -25,16 +25,18 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         errorText={errorText}
         direction={direction}
         width={width}
+        disabled={inputProps.disabled}
+        id={inputProps.id}
       >
         <Styled.Container>
           {leadingIcon && (
-            <Styled.LeftIconContainer disabled={props.disabled}>
+            <Styled.LeftIconContainer disabled={inputProps.disabled}>
               {leadingIcon}
             </Styled.LeftIconContainer>
           )}
           <Styled.Input ref={ref} {...inputProps} data-error={!!errorText} />
           {trailingIcon && (
-            <Styled.RightIconContainer disabled={props.disabled}>
+            <Styled.RightIconContainer disabled={inputProps.disabled}>
               {trailingIcon}
             </Styled.RightIconContainer>
           )}

--- a/packages/parte-ui/src/Textarea/Textarea.tsx
+++ b/packages/parte-ui/src/Textarea/Textarea.tsx
@@ -1,11 +1,10 @@
-import { forwardRef, useId, useState } from "react";
+import { forwardRef, useState } from "react";
 import { InputWrapper } from "../InputWrapper";
 import * as Styled from "./Textarea.styled";
 import { TextAreaProps } from "./Textarea.types";
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (props: TextAreaProps, ref) => {
-    const id = useId();
     const {
       label,
       description,
@@ -14,6 +13,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       onFocus,
       onBlur,
       disabled,
+      id,
       direction,
       width,
     } = props;
@@ -29,6 +29,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         errorText={errorText}
         direction={direction}
         width={width}
+        disabled={disabled}
+        id={id}
       >
         <Styled.TextareaWrapper
           hover={hover}
@@ -37,10 +39,10 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           error={!!errorText}
         >
           <Styled.Textarea
-            id={id}
             ref={ref}
             hover={hover}
             focused={focused}
+            id={id}
             {...props}
             onMouseEnter={() => setHover(true)}
             onMouseLeave={() => setHover(false)}


### PR DESCRIPTION
close #96 

- InputWrapper에 disabled일 경우에 누락 스타일 추가
- InputWrapper 쓰는 컴포넌트들 id를 넘겨주면 label에 htmlFor에 연결하도록 수정 (select는 안됨)