### PR TITLE
:bug: Radio 이슈 처리

### DIFF
--- a/apps/web/src/pages/radio.tsx
+++ b/apps/web/src/pages/radio.tsx
@@ -27,6 +27,14 @@ const RadioTest = () => {
       ))}
       <Radio label="테스트3" disabled />
       <Radio label="테스트4" checked disabled />
+      <Box
+        padding={8}
+        backgroundColor="skyblue"
+        borderRadius={4}
+        width="fit-content"
+      >
+        <Radio />
+      </Box>
     </Box>
   );
 };

--- a/packages/parte-ui/src/Radio/Radio.styled.ts
+++ b/packages/parte-ui/src/Radio/Radio.styled.ts
@@ -28,6 +28,7 @@ export const Input = styled.input`
     width: 16px;
     height: 16px;
     cursor: pointer;
+    background-color: ${theme.colors.N0};
 
     &:hover {
       border: 1px solid ${theme.colors.N600};

--- a/packages/parte-ui/src/Radio/Radio.tsx
+++ b/packages/parte-ui/src/Radio/Radio.tsx
@@ -7,7 +7,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
     return (
       <Styled.RadioWrapper>
         <Styled.Input ref={ref} type="radio" {...inputProps} />
-        <Styled.Label>{label}</Styled.Label>
+        {label && <Styled.Label>{label}</Styled.Label>}
       </Styled.RadioWrapper>
     );
   }


### PR DESCRIPTION
close #116 
- `label` 없을때는 span 그리지 않도록 고침
- Input의 기본 Background N0으로 변경