### PR TITLE
:adhesive_bandage: Icon 컴포넌트들이 기본적으로 부모의 color를 따라가도록 변경

### DIFF
--- a/packages/parte-icons/src/common/Icon.tsx
+++ b/packages/parte-icons/src/common/Icon.tsx
@@ -19,15 +19,7 @@ export interface IconProps
 }
 
 const Icon = forwardRef<HTMLSpanElement, IconProps>((props, ref) => {
-  const {
-    svg,
-    rotate,
-    style,
-    type,
-    color = "N700",
-    size = "16",
-    ...restProps
-  } = props;
+  const { svg, rotate, style, type, color, size = "16", ...restProps } = props;
 
   /**
    * span 에 기본 lineHeight 가 있으므로 오버라이드 해야함.
@@ -37,7 +29,7 @@ const Icon = forwardRef<HTMLSpanElement, IconProps>((props, ref) => {
   };
 
   const svgComponent = cloneElement(svg, {
-    color: COLORS[color],
+    color: color && COLORS[color],
     size,
     style: overrideStyle.style,
   });


### PR DESCRIPTION
## 개요
IconButton 컴포넌트를 작업하다가 발견했습니다.
아이콘을 쓰는곳들이 
```css
svg {
  color: ...;
}
```
이런식으로 스타일링을 하고 있더라구요. 이게 문제가 되는데 이유가 뭐냐면

1. Icon의 컬러가 기본값이 N700
2. Icon이 기본적으로 포함된 컴포넌트들(ex. IconButton) 들은 기본값을 덮어씌우기 위해 위 처럼 svg {} 이런 식으로 우선순위를 높게 styling하여 덮어씌우는 식으로 구성.
3. 이렇게 되니 Icon에 직접 color를 줘도 2번의 우선순위에 밀려서 color 속성이 안먹힘

그래서 Icon의 기본 color를 빼버리고 부모의 `color` 속성을 따라가되, 내가 커스텀하게 주고 싶을때는 color props로 주려면 이렇게 해야 할 것 같습니다. 일단 이렇게 바꿔도 parte에서 icon에 색상을 잘 주고 있어서 스타일이 달라지는 부분은 없는것 같아요!

> 어떻게 바뀐 부분이 없는지 확신하냐면 [chromatic](https://www.chromatic.com/build?appId=641e87e88cbcb1ee02bd69a0&number=143)에 스냅샷 변경된게 하나도 없습니다 