### PR TITLE
:bug: Toaster 생성시 id 리턴 및 pop 메소드 추가

### DIFF
--- a/apps/storybook/stories/Alerts/Toaster.stories.tsx
+++ b/apps/storybook/stories/Alerts/Toaster.stories.tsx
@@ -64,6 +64,7 @@ const DefaultToastStory = () => {
       >
         쥐가 어디있지, 쥐가 어디갔지
       </Button>
+      <Button onClick={() => toaster.pop()}>마지막 토스트 삭제</Button>
     </div>
   );
 };

--- a/packages/parte-ui/src/Toaster/ToastManager.tsx
+++ b/packages/parte-ui/src/Toaster/ToastManager.tsx
@@ -2,9 +2,10 @@ import { memo, useRef, useState } from "react";
 import { Toast } from "./Toast";
 import {
   NotifyHandler,
+  PopHandler,
   RemoveHandler,
-  ToastState,
   ToastParams,
+  ToastState,
 } from "./Toaster.types";
 
 import * as Styled from "./ToastManager.styled";
@@ -12,11 +13,13 @@ import * as Styled from "./ToastManager.styled";
 type ToastManagerProps = {
   bindNotify: (handler: NotifyHandler) => void;
   bindRemove: (hanlder: RemoveHandler) => void;
+  bindPop: (hanlder: PopHandler) => void;
 };
 
 export const ToastManager = memo(function ({
   bindNotify,
   bindRemove,
+  bindPop,
 }: ToastManagerProps) {
   const [toasts, setToasts] = useState<ToastState[]>([]);
   const idCounter = useRef(0);
@@ -72,14 +75,21 @@ export const ToastManager = memo(function ({
   };
 
   const notify: NotifyHandler = (toastState) => {
-    const tempToasts = toasts;
+    const newToast = createToastInstance(toastState);
+    setToasts((t) => [newToast, ...t]);
+    return newToast.id;
+  };
 
-    const instance = createToastInstance(toastState);
-    setToasts([instance, ...tempToasts]);
+  const popToast = () => {
+    const len = toasts.length;
+    if (len === 0) return;
+    const removeId = toasts[toasts.length - 1].id;
+    safeCloseToast(removeId);
   };
 
   bindNotify(notify);
   bindRemove(safeCloseToast);
+  bindPop(popToast);
 
   return (
     <Styled.ToastContainer>

--- a/packages/parte-ui/src/Toaster/Toaster.tsx
+++ b/packages/parte-ui/src/Toaster/Toaster.tsx
@@ -2,7 +2,7 @@ import ReactClientDOM from "react-dom/client";
 import { ThemeProvider } from "styled-components";
 import { theme } from "../@foundations/theme";
 import { ToastManager } from "./ToastManager";
-import { NotifyHandler, RemoveHandler } from "./Toaster.types";
+import { NotifyHandler, PopHandler, RemoveHandler } from "./Toaster.types";
 
 /**
  * The Toaster manages the interactions between
@@ -12,11 +12,13 @@ import { NotifyHandler, RemoveHandler } from "./Toaster.types";
 interface IToaster {
   notify: NotifyHandler;
   remove: RemoveHandler;
+  pop: PopHandler;
 }
 
 export class Toaster implements IToaster {
-  private $notifyHandler: NotifyHandler = () => {};
+  private $notifyHandler: NotifyHandler = () => 0;
   private $removeHandler: RemoveHandler = () => {};
+  private $popHandler: PopHandler = () => {};
 
   constructor() {
     const canUseDom = Boolean(typeof window !== "undefined" && window.document);
@@ -32,6 +34,7 @@ export class Toaster implements IToaster {
           <ToastManager
             bindNotify={this._bindNotify}
             bindRemove={this._bindRemove}
+            bindPop={this._bindPop}
           />
         </ThemeProvider>
       );
@@ -47,6 +50,9 @@ export class Toaster implements IToaster {
   private _bindRemove = (handler: RemoveHandler) => {
     this.$removeHandler = handler;
   };
+  private _bindPop = (handler: PopHandler) => {
+    this.$popHandler = handler;
+  };
 
   notify: NotifyHandler = (toastProps) => {
     return this.$notifyHandler(toastProps);
@@ -54,5 +60,8 @@ export class Toaster implements IToaster {
 
   remove: RemoveHandler = (id) => {
     return this.$removeHandler(id);
+  };
+  pop: PopHandler = () => {
+    return this.$popHandler();
   };
 }

--- a/packages/parte-ui/src/Toaster/Toaster.types.ts
+++ b/packages/parte-ui/src/Toaster/Toaster.types.ts
@@ -20,5 +20,6 @@ export type ToastParams = PropsWithChildren<{
   title: string;
 }>;
 
-export type NotifyHandler = (toastProps: ToastParams) => void;
+export type NotifyHandler = (toastProps: ToastParams) => number | string;
 export type RemoveHandler = (id: string | number) => void;
+export type PopHandler = () => void;


### PR DESCRIPTION
기존 Toaster는 두 가지 메소드를 가지고 있었습니다
- **notify**
- **remove**

여기서 remove 메소드는 `toastId`를 받아서 해당 토스트를 지우는 메소드입니다.
그런데 문제는 생성된 toast의 id를 알 방법이 없다는 것입니다.

그래서 2가지를 작업했는데요
- `toater.notify()` 의 return 값으로 toastId 를 반환
- `toaster.pop()` 메소드 추가

pop은 id 필요없이 가장 마지막 토스트를 삭제하는 메소드 입니다 